### PR TITLE
Fix makefile `f2py` compatibility issues

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,12 @@
 #    make clean -> removes the pyaneti.so file                            #
 #-------------------------------------------------------------------------#
 
-FP=f2py3.8
+# let users optionally override f2py, as it could 
+# vary, depending on different OSes / environments
+ifndef FP
+        FP=f2py
+endif
+#FP=f2py3.8
 #FP=f2py2.7
 fc=gnu95 
 cc=unix 

--- a/makefile
+++ b/makefile
@@ -17,8 +17,8 @@ endif
 fc=gnu95 
 cc=unix 
 
-FLAGS_OMP= -c -m --quiet --f90flags='-fopenmp'
-FLAGS = -c -m  --quiet
+FLAGS_OMP= -c --quiet --f90flags='-fopenmp' -m
+FLAGS = -c --quiet -m
 BLIBS = -llapack -lblas
 LGOMP = -lgomp
 


### PR DESCRIPTION
Provided 2 fixes for `f2py` issues in installation.

1. Make `FP` defaulted to `f2py` (instead of `f2py3.8`, and can be optionally overridden by users with environment variable, e.g., 
```shell
$ FP=fp3.8 make
```

`f2py3.8` is specific for Python 3.8 . Furthermore, in some environment, e.g., conda-based Linux, only `f2py` is provided.

---

2. In `f2py` from numpy 1.26.4, it no longer accepts the command line arguments, and generates error.

```shell
$ make
f2py -c -m --quiet pyaneti src/constants.f90 src/todo.f90 src/qpower2.f90 src/quad.f90 src/ftr.f90 src/frv.f90 src/bayesian.f90 src/matrices.f90 src/kernels.f90 src/mcmc.f90 src/multi-gp-routines.f90   --fcompiler=gnu95  -llapack -lblas --compiler=unix 
usage: f2py [--dep DEPENDENCIES] [--backend {meson,distutils}] [-m MODULE_NAME]
f2py: error: argument -m: expected one argument
make: *** [makefile:41: pyaneti] Error 2
```

The second fix moves `-m` to be immediately before `pyaneti`, so that it is accepted by f2py in numpy 1.26.4, as well as older versions (tested in 1.26.0 and 1.23.5)
```shell
# location of -m is moved
f2py -c --quiet -m pyaneti src/constants.f90  ...
```